### PR TITLE
CATL-1808: Fix typo in js

### DIFF
--- a/templates/CRM/Admin/Form/FieldIsOriginalEmlAttached.tpl
+++ b/templates/CRM/Admin/Form/FieldIsOriginalEmlAttached.tpl
@@ -21,7 +21,7 @@
   (function init() {
     // Add new field to the form.
     $('.crm-mail-settings-form-block-is_original_eml_attached')
-      .insertBefore('.crm-mail-settings-form-block-activity_status'));
+      .insertBefore('.crm-mail-settings-form-block-activity_status');
 
     // Show/hide field when 'Used For?' selected value is changed.
     $('select[name="is_default"]')


### PR DESCRIPTION
## Overview
The Mail Account settings page was broken due to js error. This PR fixes it.

## Technical Details
The error message is:
```
Uncaught SyntaxError: Unexpected token ')'          mailSettings?action=update&id=1&reset=1:317
```
So we just removed unwanted `)` (it was a typo I believe)  and this fixed the issue.