### PR TITLE
CPS-392: Fix missing 'To' field in eml file

### DIFF
--- a/CRM/Emailfiling/Service/MailProcessor.php
+++ b/CRM/Emailfiling/Service/MailProcessor.php
@@ -127,23 +127,23 @@ class CRM_Emailfiling_Service_MailProcessor {
     $message = new \Mail_mime("\n");
 
     // Add date parameter.
-    $params['Date'] = $params['Date'] ?? date(DATE_RFC822, $params['timestamp'] ?? time());
+    $params['date'] = $params['date'] ?? date(DATE_RFC822, $params['timestamp'] ?? time());
     if (isset($params['timestamp'])) {
       unset($params['timestamp']);
     }
 
     // Consolidate: 'toName' and 'toEmail' should be 'To'.
-    $toName = trim($params['toName']);
-    $toEmail = trim($params['toEmail']);
+    $toName = trim($params['toname']);
+    $toEmail = trim($params['toemail']);
     if ($toName == $toEmail || strpos($toName, '@') !== FALSE) {
       $toName = NULL;
     }
     else {
       $toName = \CRM_Utils_Mail::formatRFC2822Name($toName);
     }
-    unset($params['toName']);
-    unset($params['toEmail']);
-    $params['To'] = $toEmail ? "$toName <$toEmail>" : $params['To'];
+    unset($params['toname']);
+    unset($params['toemail']);
+    $params['to'] = $toEmail ? "$toName <$toEmail>" : $params['to'];
 
     // Apply the other fields.
     foreach ($params as $key => $value) {


### PR DESCRIPTION
## Overview
The **To** field was missing from attached eml file when sending email from a case, so if user downloads this file and opens in email viewer, recepient would not be displayed. Now it's fixed.

## Before
![image](https://user-images.githubusercontent.com/39520000/98925220-c7513c80-24e6-11eb-9589-549d5b81bd13.png)

## After
![image](https://user-images.githubusercontent.com/39520000/98925240-ccae8700-24e6-11eb-8fb1-89cf923d27b0.png)

## Technical Details
Recently (see PR #3) the `array_change_key_case()` was added to `CRM_Emailfiling_Service_MailProcessor` constructor to simplify further processing (we would not need to handle different parameter case, e.g. `Subject` / `subject`, `To` / `to`). But there is `paramsToMime()` method which was not updated and still was using different case (e.g. `toName`, `Date`).
As a result it was failed to compose `to` parameter out of `toname` and `toemail`.
Now we changed all parameter names in that class to lowercase (`paramsToMime()` method only is affected) and issue is fixed.